### PR TITLE
delete badge for contributor covenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![GitHub top language](https://img.shields.io/github/languages/top/s-suresh-kumar/yard-pal)
 [![GitHub license](https://img.shields.io/github/license/s-suresh-kumar/yard-pal)](LICENSE)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md)
 
 ```short description goes here```
 


### PR DESCRIPTION
the contributor covenant is something I usually add to my github repos, however since we are the only ones working on this project, we do not really need it. As such, I am removing the associated badge.