### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,14 +2,14 @@
 
 # dependencies
 node_modules
-/.pnp
+.pnp
 .pnp.js
 
 # testing
-/coverage
+coverage
 
 # production
-/build
+build
 
 # misc
 .DS_Store


### PR DESCRIPTION
because the react app is not in the root directory, .gitignore will not ignore directories in the react app if there is a slash in front of its name. by removing the slashes, .gitignore will ignore all directories with that name no matter where in the tree it is located. this is especially important for the build directory.